### PR TITLE
Filename Bugfix

### DIFF
--- a/src/export.go
+++ b/src/export.go
@@ -143,6 +143,7 @@ func getModule(moduleUrl string, creds Auth) (string, []string) {
 func getModuleTitle(htmlText string) string {
 	var title string
 	var isTitle bool
+	badChars := []string{"/", "\\", "?", "%", "*", ":", "|", "\"", "<", ">"}
 	tkn := html.NewTokenizer(strings.NewReader(htmlText))
 
 	for {
@@ -162,6 +163,9 @@ func getModuleTitle(htmlText string) string {
 
 			if isTitle {
 				title = t.Data
+				for _, badChar := range badChars {
+					title = strings.ReplaceAll(title, badChar, "-")
+				}
 				return title
 			}
 		case tt == html.EndTagToken:

--- a/src/export.go
+++ b/src/export.go
@@ -49,13 +49,22 @@ func authenticate(email, password string) Auth {
 }
 
 func getLoginTokenAndCookies() Auth {
+	xsrfToken := ""
+	sessionToken := ""
 	resp, err := http.Get("https://academy.hackthebox.com/login")
 	if err != nil {
 		die(err)
 	}
 	cookies := resp.Cookies()
-	if len(cookies) != 2 {
-		fmt.Printf("WARNING: An unexpected amount of cookies has been sent, expected 2, received %d cookies.\n", len(cookies))
+	for _, cookie := range cookies {
+		if cookie.Name == "XSRF-TOKEN" {
+			xsrfToken = cookie.Name + "=" + cookie.Value
+		} else if cookie.Name == "htb_academy_session" {
+			sessionToken = cookie.Name + "=" + cookie.Value
+		}
+	}
+	if xsrfToken == "" || sessionToken == "" {
+		fmt.Println("WARNING: Required cookies not found.")
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -65,7 +74,7 @@ func getLoginTokenAndCookies() Auth {
 	token := parseLoginToken(content)
 	return Auth{
 		loginToken: token,
-		cookies:    cookies[0].Name + "=" + cookies[0].Value + "; " + cookies[1].Name + "=" + cookies[1].Value,
+		cookies:    xsrfToken + ";" + sessionToken,
 	}
 }
 


### PR DESCRIPTION
- Try to ensure that filenames won't have bad characters for both Windows and Linux
- Change up warning message logic in the `getLoginTokenAndCookies` function.