### PR TITLE
Recaptcha Workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,25 @@ Check the releases folder [here](https://github.com/Tut-k0/htb-academy-to-md/rel
 All the executables listed here are for x64 and amd64. If there is not an executable for your OS or architecture, you can simply build the application. (See building section below.)
 
 ### Running
+These steps have changed slightly with the reCaptcha update on the HackTheBox platform. 
+I see this current state as a workaround for not dealing with the reCaptcha until I have more time to dig into that.
+
+Essentially instead of passing your email and password, you will just pass your authenticated session cookies to the application to use. 
+So the one added step for the workaround is manually logging into the academy (I would assume you are logged into Academy anyway to get the module URL), and extracting your cookies from your browser.
+You can fetch these with the developer tools, burp, or a browser extension, whatever works easiest for you.
+The cookies will get passed to the new `-c` argument, and you no longer need to pass an email or password.
 ```bash
 # Get the help menu displayed
 htb-academy-to-md -h
 
 # Feed the URL to the module.
-htb-academy-to-md -m https://academy.hackthebox.com/module/112/section/1060 -e <email> -p <password>
+htb-academy-to-md -m https://academy.hackthebox.com/module/112/section/1060 -c "htb_academy_session=value; XSRF-TOKEN=value; some-other-cookie=value"
 
 # Save images in module locally.
-htb-academy-to-md -m https://academy.hackthebox.com/module/112/section/1060 -e <email> -p <password> -local_images
+htb-academy-to-md -m https://academy.hackthebox.com/module/112/section/1060 -local_images -c "htb_academy_session=value; XSRF-TOKEN=value; some-other-cookie=value"
 
 # You can also grab multiple modules using a simple loop if preferred. (bash example)
-for i in $(cat modules.txt);do htb-academy-to-md -m $i -e <email> -p <password>;done
+for i in $(cat modules.txt);do htb-academy-to-md -m $i -c "htb_academy_session=value; XSRF-TOKEN=value; some-other-cookie=value";done
 ```
 
 ### Building

--- a/src/args.go
+++ b/src/args.go
@@ -4,44 +4,50 @@ import (
 	"flag"
 	"fmt"
 	"os"
-
-	"golang.org/x/term"
 )
 
 type Args struct {
-	moduleUrl   string
-	email       string
-	password    string
+	moduleUrl string
+	cookies   string
+	//email       string
+	//password    string
 	localImages bool
 }
 
 func getArguments() Args {
 	var mFlag = flag.String("m", "", "(REQUIRED) Academy Module URL to the first page.")
-	var eFlag = flag.String("e", "", "(REQUIRED) Email for your HTB account.")
-	var pFlag = flag.String("p", "", "Password for your HTB account.")
+	var cFlag = flag.String("c", "", "(REQUIRED) Academy Cookies for authorization.")
+	//var eFlag = flag.String("e", "", "(REQUIRED) Email for your HTB account.")
+	//var pFlag = flag.String("p", "", "Password for your HTB account.")
 	var imgFlag = flag.Bool("local_images", false, "Save images locally rather than referencing the URL location.")
 	flag.Parse()
 	arg := Args{
-		moduleUrl:   *mFlag,
-		email:       *eFlag,
-		password:    *pFlag,
+		moduleUrl: *mFlag,
+		cookies:   *cFlag,
+		//email:       *eFlag,
+		//password:    *pFlag,
 		localImages: *imgFlag,
 	}
 
-	if arg.moduleUrl == "" || arg.email == "" {
-		fmt.Println("Missing required arguments for module URL and HTB email. Please use the -h option for help.")
-		os.Exit(1)
-	}
+	//if arg.moduleUrl == "" || arg.email == "" {
+	//	fmt.Println("Missing required arguments for module URL and HTB email. Please use the -h option for help.")
+	//	os.Exit(1)
+	//}
+	//
+	//if arg.password == "" {
+	//	fmt.Print("Enter Password: ")
+	//	passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+	//	if err != nil {
+	//		fmt.Println("\nError reading password:", err)
+	//		os.Exit(1)
+	//	}
+	//	arg.password = string(passwordBytes)
+	//	fmt.Println()
+	//}
 
-	if arg.password == "" {
-		fmt.Print("Enter Password: ")
-		passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
-		if err != nil {
-			fmt.Println("\nError reading password:", err)
-			os.Exit(1)
-		}
-		arg.password = string(passwordBytes)
-		fmt.Println()
+	if arg.moduleUrl == "" || arg.cookies == "" {
+		fmt.Println("Missing required arguments for module URL and HTB Academy Cookies. Please use the -h option for help.")
+		os.Exit(1)
 	}
 
 	return arg

--- a/src/main.go
+++ b/src/main.go
@@ -11,7 +11,8 @@ import (
 func main() {
 	options := getArguments()
 	fmt.Println("Authenticating with HackTheBox...")
-	session := authenticate(options.email, options.password)
+	// session := authenticate(options.email, options.password)
+	session := authenticateWithCookies(options.cookies)
 	fmt.Println("Downloading requested module...")
 	title, content := getModule(options.moduleUrl, session)
 	if options.localImages {


### PR DESCRIPTION
This PR refactors the way the program authenticates with HackTheBox Academy. After reCaptcha was implemented, this seemed like the easiest way to get things working again. 

Instead of passing email and password, the program just needs to be supplied your session cookies to download a module.

- [X] Get the program to work without fighting reCaptcha

Closes #6 