### PR TITLE
Add output directory support for Markdown file generation

### DIFF
--- a/src/args.go
+++ b/src/args.go
@@ -10,17 +10,20 @@ type Args struct {
 	moduleUrl   string
 	cookies     string
 	localImages bool
+	outputDir   string
 }
 
 func getArguments() Args {
 	var mFlag = flag.String("m", "", "(REQUIRED) Academy Module URL to the first page.")
 	var cFlag = flag.String("c", "", "(REQUIRED) Academy Cookies for authorization.")
 	var imgFlag = flag.Bool("local_images", false, "Save images locally rather than referencing the URL location.")
+	var oFlag = flag.String("o", "", "Output directory for the generated Markdown file (defaults to current directory).")
 	flag.Parse()
 	arg := Args{
 		moduleUrl:   *mFlag,
 		cookies:     *cFlag,
 		localImages: *imgFlag,
+		outputDir:   *oFlag,
 	}
 
 	if arg.moduleUrl == "" || arg.cookies == "" {

--- a/src/main.go
+++ b/src/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -26,7 +27,15 @@ func main() {
 
 	markdownContent := cleanMarkdown(content)
 
-	err := os.WriteFile(title+".md", []byte(markdownContent), 0666)
+	outputPath := title + ".md"
+	if options.outputDir != "" {
+		if err := os.MkdirAll(options.outputDir, 0755); err != nil {
+			die(err)
+		}
+		outputPath = filepath.Join(options.outputDir, title+".md")
+	}
+
+	err := os.WriteFile(outputPath, []byte(markdownContent), 0666)
 	if err != nil {
 		die(err)
 	}


### PR DESCRIPTION
This pull request adds support for specifying an output directory for the generated Markdown file, allowing users to control where the file is saved. The implementation includes updates to argument parsing and file writing logic.

**New feature: Output directory support**
- Added `outputDir` field to the `Args` struct and included a new `-o` flag in argument parsing to specify the output directory. (`src/args.go`)
- Updated file writing logic in `main.go` to create the output directory if it doesn't exist and save the Markdown file there if specified. (`src/main.go`)

**Dependency update**
- Imported `filepath` package in `main.go` to handle file path operations for the output directory. (`src/main.go`)

**Issues mention**
- Resolving #17 